### PR TITLE
Fix GHA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         - ["3.10",  "py310"]
         - ["pypy3", "pypy3"]
         - ["3.9",   "coverage"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: ${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
ubuntu-latest is now 22.04 which no longer has Py27 and Py36.